### PR TITLE
MODULES-8948 rook testcase fix

### DIFF
--- a/spec/acceptance/rook_spec.rb
+++ b/spec/acceptance/rook_spec.rb
@@ -8,6 +8,9 @@ describe 'the rook module' do
       class {'kubernetes':
         controller => true,
         schedule_on_controller => true,
+        environment  => ['HOME=/root', 'KUBECONFIG=/etc/kubernetes/admin.conf'],
+        kubernetes_version => '1.13.5',
+        ignore_preflight_errors => ['NumCPU'],
       }
       "}
       it 'should run' do
@@ -17,7 +20,7 @@ describe 'the rook module' do
         shell('kubectl', :acceptable_exit_codes => [0])
       end
       it 'should install kube-dns' do
-        shell('export KUBECONFIG=/etc/kubernetes/admin.conf; kubectl get deploy --namespace kube-system kube-dns', :acceptable_exit_codes => [0])
+        shell('export KUBECONFIG=/etc/kubernetes/admin.conf; kubectl get deploy --namespace kube-system coredns', :acceptable_exit_codes => [0])
         sleep(60)
       end
     end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -41,6 +41,7 @@ RSpec.configure do |c|
       on host, puppet('module', 'install', 'puppetlabs-kubernetes'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), { :acceptable_exit_codes => [0,1] }
       on host, puppet('module', 'install', 'puppet-archive'), { :acceptable_exit_codes => [0,1] }
+      on host, puppet('module', 'install', 'stahnma-epel'), { :acceptable_exit_codes => [0,1] }
 
       # shell('echo "#{vmhostname}" > /etc/hostname')
       # shell("hostname #{vmhostname}")
@@ -125,15 +126,23 @@ EOS
 
         # Installing go, cfssl
         on(host, "cd  /etc/puppetlabs/code/environments/production/modules/kubernetes;rm -rf Gemfile.lock;bundle install --path vendor/bundle", acceptable_exit_codes: [0]).stdout
-        on(host, "curl -o go.tar.gz https://storage.googleapis.com/golang/go1.10.2.linux-amd64.tar.gz", acceptable_exit_codes: [0]).stdout
+        on(host, "curl -o go.tar.gz https://storage.googleapis.com/golang/go1.11.9.linux-amd64.tar.gz", acceptable_exit_codes: [0]).stdout
         on(host, "tar -C /usr/local -xzf go.tar.gz", acceptable_exit_codes: [0]).stdout
         on(host, "export PATH=$PATH:/usr/local/go/bin;go get -u github.com/cloudflare/cfssl/cmd/...", acceptable_exit_codes: [0]).stdout
         # Creating certs
-        on(host, "source ~/.bash_profile;rbenv global 2.3.1;rbenv local 2.3.1;export PATH=$PATH:/usr/local/go/bin;export PATH=$PATH:/root/go/bin;cd  /etc/puppetlabs/code/environments/production/modules/kubernetes/tooling;./kube_tool.rb -o #{os} -v 1.10.2 -r #{runtime} -c #{cni} -i \"#{vmhostname}:#{vmipaddr}\" -t \"#{vmipaddr}\" -a \"#{vmipaddr}\" -d true", acceptable_exit_codes: [0]).stdout
+        on(host, "source ~/.bash_profile;rbenv global 2.3.1;rbenv local 2.3.1;export PATH=$PATH:/usr/local/go/bin;export PATH=$PATH:/root/go/bin;cd  /etc/puppetlabs/code/environments/production/modules/kubernetes/tooling;./kube_tool.rb -o #{os} -v 1.13.5 -r #{runtime} -c #{cni} -i \"#{vmhostname}:#{vmipaddr}\" -t \"#{vmipaddr}\" -a \"#{vmipaddr}\" -d true", acceptable_exit_codes: [0]).stdout
         create_remote_file(host, "/etc/hosts", hosts_file)
         create_remote_file(host, "/tmp/nginx.yml", nginx)
         create_remote_file(host,"/etc/puppetlabs/puppet/hiera.yaml", hiera)
         on(host, 'cp /etc/puppetlabs/code/environments/production/modules/kubernetes/tooling/*.yaml /etc/puppetlabs/code/environments/production/hieradata/', acceptable_exit_codes: [0]).stdout
+
+        if fact('osfamily') == 'Debian'
+          on(host, 'sed -i /cni_network_provider/d /etc/puppetlabs/code/environments/production/hieradata/Debian.yaml', acceptable_exit_codes: [0]).stdout
+          on(host, 'echo "kubernetes::cni_network_provider: https://cloud.weave.works/k8s/net?k8s-version=1.13.5" >> /etc/puppetlabs/code/environments/production/hieradata/Debian.yaml', acceptable_exit_codes: [0]).stdout
+          on(host, 'echo "kubernetes::schedule_on_controller: true"  >> /etc/puppetlabs/code/environments/production/hieradata/Debian.yaml', acceptable_exit_codes: [0]).stdout
+          on(host, 'echo "kubernetes::taint_master: false" >> /etc/puppetlabs/code/environments/production/hieradata/Debian.yaml', acceptable_exit_codes: [0]).stdout
+          on(host, 'export KUBECONFIG=\'/etc/kubernetes/admin.conf\'', acceptable_exit_codes: [0]).stdout       
+        end
 
         # Disable swap
         on(host, 'swapoff -a')


### PR DESCRIPTION
Request to review the following changes

- K8 and golang version upgraded
- updated the tests

**Rook Acceptance test results**
`the rook module
  kubernetes class
    it should install the module
localhost $ scp /var/folders/4v/p90k7dqd65348jw6l6xrppdw0000gq/T/beaker20190426-47870-kecddz ubuntu-1604-master:/tmp/apply_manifest.pp.nQYIro {:ignore => }
      should run
      should install kubectl
      should install kube-dns

Finished in 5 minutes 51 seconds (files took 17 minutes 21 seconds to load)
3 examples, 0 failures`