### PR TITLE
pdksync - (IAC-1598) - Remove Support for Debian 8

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -45,7 +45,7 @@
     {
       "operatingsystem": "Debian",
       "operatingsystemrelease": [
-        "8"
+
       ]
     },
     {


### PR DESCRIPTION
(IAC-1598) - Remove Support for Debian 8
pdk version: `2.1.0` 
